### PR TITLE
Fix map layout to fill entire window

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,9 +53,10 @@
         }
         </style>
         <style>
+        /* Fill the entire window */
         #map {
-            width: 1524px;
-            height: 788px;
+            width: 100%;
+            height: 100%;
         }
         </style>
         <title></title>


### PR DESCRIPTION
## Summary
- stretch the `#map` container to 100% width and height

## Testing
- `none`

------
https://chatgpt.com/codex/tasks/task_e_68567f72e6288327a57bcd65257ef330